### PR TITLE
Update .gitignore and requirements; add goreleaser configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,181 @@ app.onefile-build/
 protodesk
 .DirIcon
 *.AppImage
+
+
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,51 @@
+project_name: protodesk
+
+# Build configuration
+builds:
+  - id: protodesk_build
+    main: ./app.py
+    binary: protodesk
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+# Archives (e.g., zip or tar.gz packages)
+archives:
+  - format: zip
+    files:
+      - LICENSE
+      - README.md
+
+# Release information
+release:
+  github:
+    owner: ######
+    name: protodesk
+
+# Artifact customization
+checksum:
+  name_template: '{{ .ProjectName }}_checksums.txt'
+
+# Windows installer (optional, using external tools)
+dockers:
+  - image_templates:
+      - '######/{{ .ProjectName }}:{{ .Version }}'
+
+# Snapcraft for Linux
+snapcraft:
+  name: protodesk
+  summary: 'A simple tool for prototyping desktop applications.'
+  description: |
+    Longer description of Protodesk.
+
+# Custom build hooks
+before:
+  hooks:
+    - go mod tidy
+after:
+  hooks:
+    - echo "Build completed!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,16 @@
+altgraph==0.17.4
 flake8==7.1.1
 mccabe==0.7.0
 Nuitka==2.5
 ordered-set==4.1.0
+packaging==24.2
 pycodestyle==2.12.1
 pyflakes==3.2.0
+pyinstaller==6.11.1
+pyinstaller-hooks-contrib==2024.10
 PySide6==6.8.0.2
 PySide6_Addons==6.8.0.2
 PySide6_Essentials==6.8.0.2
+setuptools==75.6.0
 shiboken6==6.8.0.2
 zstandard==0.23.0


### PR DESCRIPTION
This pull request introduces a new configuration file `.goreleaser.yaml` to automate the release process for the `protodesk` project. The configuration includes build settings, archive formats, release information, and custom build hooks.

Key changes include:

* **Project and Build Configuration:**
  * Added project name `protodesk`.
  * Defined build settings for different operating systems (`windows`, `linux`, `darwin`) and architectures (`amd64`, `arm64`). (`[.goreleaser.yamlR1-R51](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R51)`)

* **Archive and Release Information:**
  * Configured archives to include `LICENSE` and `README.md` files in `zip` format.
  * Added GitHub release information with placeholders for owner and repository name. (`[.goreleaser.yamlR1-R51](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R51)`)

* **Artifact Customization:**
  * Configured checksum naming template and Docker image templates for version tagging. (`[.goreleaser.yamlR1-R51](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R51)`)

* **Snapcraft Configuration:**
  * Added Snapcraft settings for Linux, including name, summary, and description of the project. (`[.goreleaser.yamlR1-R51](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R51)`)

* **Custom Build Hooks:**
  * Added pre-build and post-build hooks to tidy Go modules and print a completion message. (`[.goreleaser.yamlR1-R51](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R1-R51)`)